### PR TITLE
adds isPrivate and new corresponding ts file for later changes if needed

### DIFF
--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -26,6 +26,7 @@ require('./bookmarks')(Posts);
 require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);
+require('./privacy')(Posts);
 
 Posts.exists = async function (pids) {
     return await db.exists(

--- a/src/posts/privacy.js
+++ b/src/posts/privacy.js
@@ -1,0 +1,13 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+const database_1 = __importDefault(require("../database"));
+module.exports = function (Posts) {
+    Posts.getPrivate = async function (pid, uid) {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = await database_1.default.isMemberOfSets([`pid:${pid}:isPrivate`], uid);
+        return { isPrivate: result };
+    };
+};

--- a/src/posts/privacy.ts
+++ b/src/posts/privacy.ts
@@ -1,0 +1,14 @@
+import db from '../database';
+
+interface Posts {
+    getPrivate: (pid: number, uid: number) => Promise<{isPrivate: boolean}>,
+}
+
+export = function (Posts: Posts) {
+    Posts.getPrivate = async function (pid: number, uid: number): Promise<{isPrivate: boolean}> {
+        // The next line calls a function in a module that has not been updated to TS yet
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const result = await db.isMemberOfSets([`pid:${pid}:isPrivate`], uid) as boolean;
+        return { isPrivate: result };
+    };
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -18,4 +18,5 @@ export type PostObject = {
   category: CategoryObject;
   isMainPost: boolean;
   replies: number;
+  isPrivate: boolean;
 };


### PR DESCRIPTION
This pull request is supposed to resolve #18. I named the flag 'isPrivate' instead of 'is_private' to use a consistent pattern with the other PostObject properties. The files modified are designed to create posts with the flag, and I added a privacy.ts in case more needs to be done with this flag in the future which is very likely. There is a dependency change to a js file while is not converted to ts, but everything else is consistent. I believe it passes all tests.