### PR TITLE
Added new post notification type and functionality to filter notifications

### DIFF
--- a/install/data/defaults.json
+++ b/install/data/defaults.json
@@ -107,6 +107,7 @@
     "notificationType_group-invite": "notification",
     "notificationType_group-leave": "notification",
     "notificationType_group-request-membership": "notification",
+    "notificationType_new-post": "notification",
     "notificationType_mention": "notification",
     "notificationType_new-register": "notification",
     "notificationType_post-queue": "notification",

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -29,6 +29,7 @@ Notifications.baseTypes = [
     'notificationType_group-invite',
     'notificationType_group-leave',
     'notificationType_group-request-membership',
+    'notificationType_new-post',
 ];
 
 Notifications.privilegedTypes = [
@@ -147,8 +148,16 @@ Notifications.push = async function (notification, uids) {
         return;
     }
     uids = Array.isArray(uids) ? _.uniq(uids) : [uids];
-    if (!uids.length) {
-        return;
+
+    if (notification.type === 'notificationType_new-post') {
+        if (posts.getPostField(posts.pid, 'isPrivate') === false) {
+            uids = Array.isArray(uids) ? _.uniq(uids) : [uids];
+            if (!uids.length) {
+                return;
+            }
+        } else {
+            uids = uids.filter(Checkacounttype);
+        }
     }
 
     setTimeout(() => {
@@ -161,7 +170,10 @@ Notifications.push = async function (notification, uids) {
         });
     }, 1000);
 };
-
+function Checkacounttype(value) {
+    const PATTERN = 'instructor';
+    return value.accounttype === PATTERN;
+}
 async function pushToUids(uids, notification) {
     async function sendNotification(uids) {
         if (!uids.length) {


### PR DESCRIPTION
In reference to issues  https://github.com/CMU-313/spring23-nodebb-team-c1/issues/16 and https://github.com/CMU-313/spring23-nodebb-team-c1/issues/15. I was able to add a notification type, 'notificationType_new-post"  for posts to help filter out posts that were marked as private to other student accounts. Also added the actual filtering functionality to posts marked as private inside of src/notifications.js. Further integration of 'notificationType_new-post' may be needed in the next sprint to address the full suite of features this user story requires.