### PR TITLE
Fixing the lack of the NotificationType_new-post in the database schema

### DIFF
--- a/public/openapi/components/schemas/SettingsObj.yaml
+++ b/public/openapi/components/schemas/SettingsObj.yaml
@@ -67,6 +67,9 @@ Settings:
     notificationType_post-edit:
       type: string
       description: Notification type for post edits
+    notificationType_new-post:
+      type: string
+      description: Notification type for new posts
     sendChatNotifications:
       nullable: true
     sendPostNotifications:
@@ -141,6 +144,7 @@ Settings:
     - notificationType_follow
     - notificationType_group-invite
     - notificationType_group-leave
+    - notificationType_new-post
     - upvoteNotifFreq
     - acpLang
     - notificationType_new-register

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -34,6 +34,7 @@ export type SettingsObject = {
   'notificationType_new-register': string;
   'notificationType_post-queue': string;
   'notificationType_new-post-flag': string;
+  'notificationType_new-post': string;
   'notificationType_new-user-flag': string;
   categoryWatchState: string;
   'notificationType_group-request-membership': string;


### PR DESCRIPTION
As the title states Added the new notification type NotificationType_new-post to the files:

- public/openapi/components/schemas/SettingsObj.yaml
- src/types/settings.ts

as they have been determined to the files where the lack of the notification type cause the error in the GitHub action tests