### PR TITLE
Addition of an extra endorse test and fixing the previous test

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -12,9 +12,10 @@ To use and test it:
 7. Create a student account and verify that you cannot endorse posts.
 
 ### Tests
-The tests for this feature can be found in test/posts.js on lines 310-334. They test three behaviors:
+The tests for this feature can be found in test/posts.js on lines 310-344. They test three behaviors:
 1. An instructor should be able to endorse a post
 2. An instructor should be able to unendorse a post
 3. A student should get an error when trying to endorse a post
+4. A student should get an error when trying to unendorse a post
 
-These are the three desired behaviors for the backend.
+These are the four desired behaviors for the backend.

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -94,7 +94,6 @@ module.exports = function (Topics) {
     Topics.create = async function (data) {
         // This is an internal method, consider using Topics.post instead
         const timestamp = data.timestamp || Date.now();
-
         // The next line calls a function in a module that has not been updated to TS yet
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
         const tid = await db.incrObjectField('global', 'nextTid');
@@ -110,6 +109,7 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            isPrivate: data.isPrivate,
         };
         if (Array.isArray(data.tags) && data.tags.length) {
             topicData.tags = data.tags.join(',');

--- a/test/posts.js
+++ b/test/posts.js
@@ -324,6 +324,16 @@ describe('Post\'s', () => {
 
         it('should not endorse a post as a student', async () => {
             try {
+                await apiPosts.endorse(
+                    { uid: voterUid },
+                    { pid: postData.pid, room_id: `topic_${postData.tid}` }
+                );
+                assert(false, 'should have thrown');
+            } catch (_) {}
+        });
+
+        it('should not unendorse a post as a student', async () => {
+            try {
                 await apiPosts.unendorse(
                     { uid: voterUid },
                     { pid: postData.pid, room_id: `topic_${postData.tid}` }


### PR DESCRIPTION
This pull request is a minor add-on to #36 and meant to resolve #37. Previously, there was a test stating "should not endorse a post as a student", but it was testing unendorse. I changed this by splitting it into two tests which test both parts as intended. The tests should still run successfully.